### PR TITLE
Make odate work with OCaml >4.06 and OPAM >2.0

### DIFF
--- a/odate.opam
+++ b/odate.opam
@@ -12,5 +12,5 @@ depends: [
   "base-unix"
 ]
 dev-repo: "git://github.com/hhugo/odate"
-available: [ ocaml-version >= "4.00.0" ]
+available: [ ocaml-version >= "4.07.0" ]
 

--- a/odate.opam
+++ b/odate.opam
@@ -1,16 +1,23 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "hugo.heuzard@gmail.com"
 authors: [ "Hugo Heuzard" ]
 license: "LGPL-2.1 with OCaml linking exception"
 homepage: "https://github.com/hhugo/odate"
 build: [
-  ["dune" "build" "--only" "odate" "--root" "." "-j" jobs "@install"]
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
+  "ocaml" {>= "4.07.0"}
   "dune" {build}
   "menhir" {build}
   "base-unix"
 ]
+synopsis: "Date & Duration Library"
+description: """
+Simple date and duration manipulation. Also implement duration printer
+based on string format. Already implemented in opalang
+[http://opalang.org/]. For documentation about the format, see :
+[http://doc.opalang.org/value/stdlib.core.date/Duration/try_generate_printer].
+"""
 dev-repo: "git://github.com/hhugo/odate"
-available: [ ocaml-version >= "4.07.0" ]
-

--- a/src/duration_private.ml
+++ b/src/duration_private.ml
@@ -1,4 +1,4 @@
-module P = Pervasives
+module P = Stdlib
 
 module O : sig
 

--- a/src/oDate.ml
+++ b/src/oDate.ml
@@ -939,7 +939,7 @@ end
 module MakeImplem(C : Clock) : Implem = struct
   type t = float
 
-  let compare = Pervasives.compare
+  let compare = Stdlib.compare
 
   let add f i = f +. i
   let from_seconds x = x


### PR DESCRIPTION
Right now oDate cannot be built and installed with OCaml >4.06 and OPAM 2.x. This is unfortunate because there's no better library for parsing datetime strings!
calendar is fine for parsing _dates_, but its implementation doesn't work right with formats that include both date and time (https://github.com/ocaml-community/calendar/issues/35).

Thus I really would love to see a new release of oDate. These patches update the code to use `Stdlib` rather than old-style `Pervasives`. Since there's only one dependent package ([coclobas](https://opam.ocaml.org/packages/coclobas/)), I believe it will not cause big problems.
@smondet Please confirm or deny whether you are fine with this change.

The OPAM file now works with 2.0 and should be ready for a PR. I successfully did `opam pin add .` with OCaml 4.10 and opam 2.0.7:

```
utop # ODate.Unix.From.string (ODate.Unix.From.generate_parser "%F %H:%M" |> Option.get) "2020-11-17 06:05" |> ODate.Unix.Printer.to_iso ;;
- : string = "2020-11-17T06:05:00Z"
```