### PR TITLE
Re-raise Invalid_argument as Failure for uniform error reporting

### DIFF
--- a/src/oDate.ml
+++ b/src/oDate.ml
@@ -760,7 +760,8 @@ module Make (Implem : Implem) = struct
 
     let string (parser_ : parser_) (s : string) =
       let ptr = make_state s in
-      human (parser_ ptr empty)
+      try human (parser_ ptr empty)
+      with Invalid_argument s -> failwith s
   end
 
   module To = struct


### PR DESCRIPTION
Right now most malformed dates will cause a `Failure`, but in certain situations, `Invalid_argument` is raised instead.

For example:

```ocaml
utop # ODate.Unix.Parser.from_iso "2020-12" ;;
Exception: Invalid_argument "index out of bounds".
```
It's caused by trying to address a non-existent string index, like [here](https://github.com/hhugo/odate/blob/master/src/oDate.ml#L491).

However, the user should never receive `Invalid_argument` from a library unless the error is on the user's side [1].

Ideally, the logic itself should be made more robust and account for possibly missing date components, but this PR fixes the immediate problem by catching `Invalid_argument` (even if it's against the guideline) and re-raising it as `Failure`.

[1] As https://ocaml.org/manual/core.html#ss:predef-exn says, `Failure` should be "raised by library functions to signal that they are undefined on the given arguments", while `Invalid_argument` is "raised by library functions to signal that the given arguments do not make sense... As a general rule, this exception should not be caught, it denotes a programming error and the code should be modified not to trigger it. "
