### PR TITLE
switch to menhir 2.0, infer types

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
 (lang dune 2.2)
 (formatting (enabled_for ocaml))
 (name odate)
-(using menhir 1.0)
+(using menhir 2.0)


### PR DESCRIPTION
Building with newer versions of menhir (20220210 and 20230608) resulted in an error saying that types of non-terminals were not specified and that automatic type inference needs to be specifically enabled.

Updating to menhir 2.0 allows for types to be inferred.

Error output: https://dpaste.com/D7XAP64EP
Menhir docs: http://gallium.inria.fr/~fpottier/menhir/manual.html#dune